### PR TITLE
Fix nodelist initialization accumulator

### DIFF
--- a/src/mem3_nodes.erl
+++ b/src/mem3_nodes.erl
@@ -96,10 +96,10 @@ initialize_nodelist() ->
     couch_db:close(Db),
     {Nodes, Db#db.update_seq}.
 
-first_fold(#full_doc_info{id = <<"_design/", _/binary>>}, _, {_Db, Dict}) ->
-    {ok, Dict};
-first_fold(#full_doc_info{deleted=true}, _, {_Db, Dict}) ->
-    {ok, Dict};
+first_fold(#full_doc_info{id = <<"_design/", _/binary>>}, _, Acc) ->
+    {ok, Acc};
+first_fold(#full_doc_info{deleted=true}, _, Acc) ->
+    {ok, Acc};
 first_fold(#full_doc_info{id=Id}=DocInfo, _, {Db, Dict}) ->
     {ok, #doc{body={Props}}} = couch_db:open_doc(Db, DocInfo),
     {ok, {Db, dict:store(mem3_util:to_atom(Id), Props, Dict)}}.


### PR DESCRIPTION
The tree fold returned a malformed accumulator in the case of deleted nodes or design documents in the nodes database.  This would crash mem3 immediately and prevent the node from starting up.

BugzID: 12576
