### PR TITLE
Improve creating and deleting of shard_db docs

### DIFF
--- a/src/mem3_util.erl
+++ b/src/mem3_util.erl
@@ -107,7 +107,7 @@ delete_db_doc(DbName, DocId, ShouldMutate) ->
     {ok, Revs} = couch_db:open_doc_revs(Db, DocId, all, []),
     try [Doc#doc{deleted=true} || {ok, #doc{deleted=false}=Doc} <- Revs] of
     [] ->
-        ok;
+        not_found;
     Docs when ShouldMutate ->
         try couch_db:update_docs(Db, Docs, []) of
         {ok, _} ->


### PR DESCRIPTION
When creating a db detect conflicts when writing the shard_db doc and fail. When deleting the shard_db doc
make sure multiple leafs that might occur from deleting and re-creating the same db are all deleted.

BugzID:12220

(Resubmission of https://github.com/cloudant/mem3/pull/8 with a new branch name).
