### PR TITLE
Add a manager for node syncrhonization

### DIFF
--- a/src/mem3.app.src
+++ b/src/mem3.app.src
@@ -7,6 +7,7 @@
         mem3_nodes,
         mem3_shards,
         mem3_sync,
+        mem3_sync_nodes,
         mem3_sup
     ]},
     {applications, [kernel, stdlib, sasl, crypto, mochiweb, couch]}

--- a/src/mem3_sup.erl
+++ b/src/mem3_sup.erl
@@ -22,6 +22,7 @@ start_link() ->
 init(_Args) ->
     Children = [
         child(mem3_events),
+        child(mem3_sync_nodes), % Order important?
         child(mem3_sync),
         child(mem3_shards),
         child(mem3_nodes)

--- a/src/mem3_sync.erl
+++ b/src/mem3_sync.erl
@@ -65,7 +65,7 @@ init([]) ->
     Concurrency = couch_config:get("mem3", "sync_concurrency", "10"),
     gen_event:add_handler(mem3_events, mem3_sync_event, []),
     {ok, Pid} = start_update_notifier(),
-    spawn(fun initial_sync/0),
+    initial_sync(),
     {ok, #state{limit = list_to_integer(Concurrency), update_notifier=Pid}}.
 
 handle_call({push, Job}, From, State) ->
@@ -216,7 +216,7 @@ sync_nodes_and_dbs() ->
 
 initial_sync() ->
     [net_kernel:connect_node(Node) || Node <- mem3:nodes()],
-    initial_sync(nodes()).
+    mem3_sync_nodes:add(nodes()).
 
 initial_sync(Live) ->
     sync_nodes_and_dbs(),

--- a/src/mem3_sync_event.erl
+++ b/src/mem3_sync_event.erl
@@ -24,7 +24,7 @@ init(_) ->
 
 handle_event({add_node, Node}, State) when Node =/= node() ->
     net_kernel:connect_node(Node),
-    mem3_sync:initial_sync([Node]),
+    mem3_sync_nodes:add([Node]),
     {ok, State};
 
 handle_event({remove_node, Node}, State)  ->
@@ -40,7 +40,7 @@ handle_call(_Request, State) ->
 handle_info({nodeup, Node}, State) ->
     case lists:member(Node, mem3:nodes()) of
     true ->
-        mem3_sync:initial_sync([Node]);
+        mem3_sync_nodes:add([Node]);
     false ->
         ok
     end,

--- a/src/mem3_sync_nodes.erl
+++ b/src/mem3_sync_nodes.erl
@@ -1,0 +1,116 @@
+% Copyright 2012 Cloudant
+%
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(mem3_sync_nodes).
+-behaviour(gen_server).
+
+
+-export([start_link/0]).
+-export([add/1]).
+
+-export([init/1, terminate/2, code_change/3]).
+-export([handle_call/3, handle_cast/2, handle_info/2]).
+
+-export([monitor_sync/1]).
+
+
+-record(st, {
+    tid
+}).
+
+
+-record(job, {
+    nodes,
+    pid,
+    retry
+}).
+
+
+start_link() ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+
+add(Nodes) ->
+    gen_server:cast(?MODULE, {add, Nodes}).
+
+
+init([]) ->
+    {ok, #st{
+        tid = ets:new(?MODULE, [set, protected, {keypos, #job.nodes}])
+    }}.
+
+
+terminate(_Reason, St) ->
+    [exit(Pid, kill) || #job{pid=Pid} <- ets:tab2list(St#st.tid)],
+    ok.
+
+
+handle_call(Msg, _From, St) ->
+    {stop, {invalid_call, Msg}, invalid_call, St}.
+
+
+handle_cast({add, Nodes}, #st{tid=Tid}=St) ->
+    case ets:lookup(Tid, Nodes) of
+        [] ->
+            Pid = start_sync(Nodes),
+            ets:insert(Tid, #job{nodes=Nodes, pid=Pid, retry=false});
+        [#job{retry=false}=Job] ->
+            ets:insert(Tid, Job#job{retry=true});
+        _ ->
+            ok
+    end,
+    {noreply, St};
+
+handle_cast(Msg, St) ->
+    {stop, {invalid_cast, Msg}, St}.
+
+
+handle_info({'DOWN', _, _, _, {sync_done, Nodes}}, #st{tid=Tid}=St) ->
+    case ets:lookup(Tid, Nodes) of
+        [#job{retry=true}=Job] ->
+            Pid = start_sync(Nodes),
+            ets:insert(Tid, Job#job{pid=Pid, retry=false});
+        _ ->
+            ets:delete(Tid, Nodes)
+    end,
+    {noreply, St};
+
+handle_info({'DOWN', _, _, _, {sync_error, Nodes}}, #st{tid=Tid}=St) ->
+    Pid = start_sync(Nodes),
+    ets:insert(Tid, #job{nodes=Nodes, pid=Pid, retry=false}),
+    {noreply, St};
+
+handle_info(Msg, St) ->
+    {stop, {invalid_info, Msg}, St}.
+
+
+code_change(_OldVsn, St, _Extra) ->
+    {ok, St}.
+
+
+start_sync(Nodes) ->
+    {Pid, _} = spawn_monitor(?MODULE, monitor_sync, [Nodes]),
+    Pid.
+
+
+monitor_sync(Nodes) ->
+    process_flag(trap_exit, true),
+    Pid = spawn_link(mem3_sync, initial_sync, [Nodes]),
+    receive
+        {'EXIT', Pid, normal} ->
+            exit({sync_done, Nodes});
+        _ ->
+            exit({sync_error, Nodes})
+    end.
+


### PR DESCRIPTION
Fixes deadlocks in the synchronous synchronization of databases when a node boots.
