### PR TITLE
Fix stuck internal replications after node down

### DIFF
--- a/src/mem3_sync.erl
+++ b/src/mem3_sync.erl
@@ -317,7 +317,9 @@ is_running(DbName, Node, ActiveList) ->
     [] =/= [true || #job{name=S, node=N} <- ActiveList, S=:=DbName, N=:=Node].
 
 remove_entries(Dict, Entries) ->
-    lists:foldl(fun(Entry, D) -> dict:erase(Entry, D) end, Dict, Entries).
+    lists:foldl(fun(#job{name=S, node=N}, D) ->
+        dict:erase({S, N}, D)
+    end, Dict, Entries).
 
 local_dbs() ->
     [nodes_db(), shards_db(), users_db()].


### PR DESCRIPTION
We weren't removing entries from the dict tracking what was in the job
queue. This looks like a bug after the switch from tuples to the #job{}
record which means its probably been around for quite awhile. Simple fix
is simply to use the correct dict key.

BugzId: 14654
