### PR TITLE
Don't resurrect shards on deletion

### DIFF
--- a/src/mem3_nodes.erl
+++ b/src/mem3_nodes.erl
@@ -138,7 +138,7 @@ changes_callback({stop, EndSeq}, _) ->
 changes_callback({change, {Change}, _}, _) ->
     Node = couch_util:get_value(<<"id">>, Change),
     case Node of <<"_design/", _/binary>> -> ok; _ ->
-        case is_deleted(Change) of
+        case mem3_util:is_deleted(Change) of
         false ->
             {Props} = couch_util:get_value(doc, Change),
             gen_server:call(?MODULE, {add_node, mem3_util:to_atom(Node), Props});
@@ -149,12 +149,3 @@ changes_callback({change, {Change}, _}, _) ->
     {ok, couch_util:get_value(<<"seq">>, Change)};
 changes_callback(timeout, _) ->
     {ok, nil}.
-
-is_deleted(Change) ->
-    case couch_util:get_value(<<"deleted">>, Change) of
-    undefined ->
-        % keep backwards compatibility for a while
-        couch_util:get_value(deleted, Change, false);
-    Else ->
-        Else
-    end.

--- a/src/mem3_shards.erl
+++ b/src/mem3_shards.erl
@@ -207,7 +207,7 @@ changes_callback({stop, EndSeq}, _) ->
 changes_callback({change, {Change}, _}, _) ->
     DbName = couch_util:get_value(<<"id">>, Change),
     case DbName of <<"_design/", _/binary>> -> ok; _Else ->
-        case couch_util:get_value(deleted, Change, false) of
+        case mem3_util:is_deleted(Change) of
         true ->
             gen_server:cast(?MODULE, {cache_remove, DbName});
         false ->

--- a/src/mem3_util.erl
+++ b/src/mem3_util.erl
@@ -17,7 +17,7 @@
 -export([hash/1, name_shard/2, create_partition_map/5, build_shards/2,
     n_val/2, to_atom/1, to_integer/1, write_db_doc/1, delete_db_doc/1,
     shard_info/1, ensure_exists/1, open_db_doc/1]).
--export([owner/2]).
+-export([owner/2, is_deleted/1]).
 
 -export([create_partition_map/4, name_shard/1]).
 -deprecated({create_partition_map, 4, eventually}).
@@ -187,3 +187,12 @@ owner(DbName, DocId) ->
     [#shard{node=Node}] = lists:usort(fun(#shard{name=A}, #shard{name=B}) ->
                                               A =< B  end, LiveShards),
     node() =:= Node.
+
+is_deleted(Change) ->
+    case couch_util:get_value(<<"deleted">>, Change) of
+    undefined ->
+        % keep backwards compatibility for a while
+        couch_util:get_value(deleted, Change, false);
+    Else ->
+        Else
+    end.


### PR DESCRIPTION
In bigcouch and bigcouchplus (at least) the deleted property is a
binary, <<"deleted">>, and not an atom, deleted, as it used to
be. This causes mem3_shards to recreate a shard immediately after it
is deleted, leading to profound silliness.

BugzID: 15924
