### PR TITLE
If two shards differ we need to sync

### DIFF
--- a/src/mem3_sync_security.erl
+++ b/src/mem3_sync_security.erl
@@ -37,6 +37,8 @@ maybe_sync_int(#shard{name=Name}=Src, Dst) ->
                 1 -> ok;
                 2 -> go(DbName)
             end;
+        {error, no_majority} ->
+            go(DbName);
         Else ->
             Args = [DbName, Else],
             twig:log(err, "Error checking security objects for ~s :: ~p", Args)


### PR DESCRIPTION
There's no security if two shards return different answers but it gives
us enough of a signal to know that we need to trigger a full on
synchronization.

BugzId: 18955
