### PR TITLE
Choose ushards according to persistent record

### DIFF
--- a/include/mem3.hrl
+++ b/include/mem3.hrl
@@ -21,6 +21,16 @@
     ref :: reference() | 'undefined' | '_'
 }).
 
+%% Do not reference outside of mem3.
+-record(ordered_shard, {
+    name :: binary() | '_',
+    node :: node() | '_',
+    dbname :: binary(),
+    range :: [non_neg_integer() | '$1' | '$2'],
+    ref :: reference() | 'undefined' | '_',
+    order :: non_neg_integer() | 'undefined' | '_'
+}).
+
 %% types
 -type join_type() :: init | join | replace | leave.
 -type join_order() :: non_neg_integer().

--- a/src/mem3_shards.erl
+++ b/src/mem3_shards.erl
@@ -21,7 +21,7 @@
 -export([handle_config_change/5]).
 
 -export([start_link/0]).
--export([for_db/1, for_docid/2, get/3, local/1, fold/2]).
+-export([for_db/1, for_db/2, for_docid/2, for_docid/3, get/3, local/1, fold/2]).
 -export([set_max_size/1]).
 
 -record(st, {
@@ -41,7 +41,10 @@ start_link() ->
     gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
 
 for_db(DbName) ->
-    try ets:lookup(?SHARDS, DbName) of
+    for_db(DbName, []).
+
+for_db(DbName, Options) ->
+    Shards = try ets:lookup(?SHARDS, DbName) of
         [] ->
             load_shards_from_disk(DbName);
         Else ->
@@ -49,26 +52,47 @@ for_db(DbName) ->
             Else
     catch error:badarg ->
         load_shards_from_disk(DbName)
+    end,
+    case lists:member(ordered, Options) of
+        true  -> Shards;
+        false -> mem3_util:downcast(Shards)
     end.
 
 for_docid(DbName, DocId) ->
+    for_docid(DbName, DocId, []).
+
+for_docid(DbName, DocId, Options) ->
     HashKey = mem3_util:hash(DocId),
-    Head = #shard{
+    ShardHead = #shard{
         name = '_',
         node = '_',
         dbname = DbName,
         range = ['$1','$2'],
         ref = '_'
     },
+    OrderedShardHead = #ordered_shard{
+        name = '_',
+        node = '_',
+        dbname = DbName,
+        range = ['$1','$2'],
+        ref = '_',
+        order = '_'
+    },
     Conditions = [{'=<', '$1', HashKey}, {'=<', HashKey, '$2'}],
-    try ets:select(?SHARDS, [{Head, Conditions, ['$_']}]) of
+    ShardSpec = {ShardHead, Conditions, ['$_']},
+    OrderedShardSpec = {OrderedShardHead, Conditions, ['$_']},
+    Shards = try ets:select(?SHARDS, [ShardSpec, OrderedShardSpec]) of
         [] ->
             load_shards_from_disk(DbName, DocId);
-        Shards ->
+        Else ->
             gen_server:cast(?MODULE, {cache_hit, DbName}),
-            Shards
+            Else
     catch error:badarg ->
         load_shards_from_disk(DbName, DocId)
+    end,
+    case lists:member(ordered, Options) of
+        true  -> Shards;
+        false -> mem3_util:downcast(Shards)
     end.
 
 get(DbName, Node, Range) ->
@@ -226,10 +250,10 @@ changes_callback({change, {Change}, _}, _) ->
                 twig:log(error, "missing partition table for ~s: ~p",
                     [DbName, Reason]);
             {Doc} ->
-                Shards = mem3_util:build_shards(DbName, Doc),
+                Shards = mem3_util:build_ordered_shards(DbName, Doc),
                 gen_server:cast(?MODULE, {cache_insert, DbName, Shards}),
-                [create_if_missing(Name) || #shard{name=Name, node=Node}
-                    <- Shards, Node =:= node()]
+                [create_if_missing(mem3:name(S)) || S
+                    <- Shards, mem3:node(S) =:= node()]
             end
         end
     end,
@@ -249,7 +273,7 @@ load_shards_from_disk(DbName) when is_binary(DbName) ->
 load_shards_from_db(#db{} = ShardDb, DbName) ->
     case couch_db:open_doc(ShardDb, DbName, []) of
     {ok, #doc{body = {Props}}} ->
-        Shards = mem3_util:build_shards(DbName, Props),
+        Shards = mem3_util:build_ordered_shards(DbName, Props),
         gen_server:cast(?MODULE, {cache_insert, DbName, Shards}),
         Shards;
     {not_found, _} ->
@@ -331,4 +355,3 @@ cache_clear(St) ->
     true = ets:delete_all_objects(?SHARDS),
     true = ets:delete_all_objects(?ATIMES),
     St#st{cur_size=0}.
-

--- a/src/mem3_util.erl
+++ b/src/mem3_util.erl
@@ -19,6 +19,9 @@
     shard_info/1, ensure_exists/1, open_db_doc/1]).
 -export([owner/2, is_deleted/1]).
 
+%% do not use outside mem3.
+-export([build_ordered_shards/2, downcast/1]).
+
 -export([create_partition_map/4, name_shard/1]).
 -deprecated({create_partition_map, 4, eventually}).
 -deprecated({name_shard, 1, eventually}).
@@ -36,10 +39,17 @@ hash(Item) ->
 name_shard(Shard) ->
     name_shard(Shard, "").
 
-name_shard(#shard{dbname = DbName, range=[B,E]} = Shard, Suffix) ->
-    Name = ["shards/", couch_util:to_hex(<<B:32/integer>>), "-",
-        couch_util:to_hex(<<E:32/integer>>), "/", DbName, Suffix],
-    Shard#shard{name = ?l2b(Name)}.
+name_shard(#shard{dbname = DbName, range=Range} = Shard, Suffix) ->
+    Name = make_name(DbName, Range, Suffix),
+    Shard#shard{name = ?l2b(Name)};
+
+name_shard(#ordered_shard{dbname = DbName, range=Range} = Shard, Suffix) ->
+    Name = make_name(DbName, Range, Suffix),
+    Shard#ordered_shard{name = ?l2b(Name)}.
+
+make_name(DbName, [B,E], Suffix) ->
+    ["shards/", couch_util:to_hex(<<B:32/integer>>), "-",
+     couch_util:to_hex(<<E:32/integer>>), "/", DbName, Suffix].
 
 create_partition_map(DbName, N, Q, Nodes) ->
     create_partition_map(DbName, N, Q, Nodes, "").
@@ -124,7 +134,25 @@ delete_db_doc(DbName, DocId, ShouldMutate) ->
         couch_db:close(Db)
     end.
 
+%% Always returns original #shard records.
+-spec build_shards(binary(), list()) -> [#shard{}].
 build_shards(DbName, DocProps) ->
+    build_shards_by_node(DbName, DocProps).
+
+%% Will return #ordered_shard records if by_node and by_range
+%% are symmetrical, #shard records otherwise.
+-spec build_ordered_shards(binary(), list()) ->
+    [#shard{}] | [#ordered_shard{}].
+build_ordered_shards(DbName, DocProps) ->
+    ByNode = build_shards_by_node(DbName, DocProps),
+    ByRange = build_shards_by_range(DbName, DocProps),
+    Symmetrical = lists:sort(ByNode) =:= lists:sort(downcast(ByRange)),
+    case Symmetrical of
+        true  -> ByRange;
+        false -> ByNode
+    end.
+
+build_shards_by_node(DbName, DocProps) ->
     {ByNode} = couch_util:get_value(<<"by_node">>, DocProps, {[]}),
     Suffix = couch_util:get_value(<<"shard_suffix">>, DocProps, ""),
     lists:flatmap(fun({Node, Ranges}) ->
@@ -139,6 +167,23 @@ build_shards(DbName, DocProps) ->
             }, Suffix)
         end, Ranges)
     end, ByNode).
+
+build_shards_by_range(DbName, DocProps) ->
+    {ByRange} = couch_util:get_value(<<"by_range">>, DocProps, {[]}),
+    Suffix = couch_util:get_value(<<"shard_suffix">>, DocProps, ""),
+    lists:flatmap(fun({Range, Nodes}) ->
+        lists:map(fun({Node, Order}) ->
+            [B,E] = string:tokens(?b2l(Range), "-"),
+            Beg = httpd_util:hexlist_to_integer(B),
+            End = httpd_util:hexlist_to_integer(E),
+            name_shard(#ordered_shard{
+                dbname = DbName,
+                node = to_atom(Node),
+                range = [Beg, End],
+                order = Order
+            }, Suffix)
+        end, lists:zip(Nodes, lists:seq(1, length(Nodes))))
+    end, ByRange).
 
 to_atom(Node) when is_binary(Node) ->
     list_to_atom(binary_to_list(Node));
@@ -196,3 +241,16 @@ is_deleted(Change) ->
     Else ->
         Else
     end.
+
+downcast(#shard{}=S) ->
+    S;
+downcast(#ordered_shard{}=S) ->
+    #shard{
+       name = S#ordered_shard.name,
+       node = S#ordered_shard.node,
+       dbname = S#ordered_shard.dbname,
+       range = S#ordered_shard.range,
+       ref = S#ordered_shard.ref
+      };
+downcast(Shards) when is_list(Shards) ->
+    [downcast(Shard) || Shard <- Shards].


### PR DESCRIPTION
The order of nodes in the by_range section of "dbs" documents is now
promoted to the principal order for ushards. Ushards still accounts
for Liveness, selecting the first live replica and still supports
Spread by rotating this list using the CRC32 of the database name
(since many databases will have the same layout).

If by_range and by_node are not symmetrical then by_node is used and
order is undefined to match existing behavior.
