### PR TITLE
Balance replication ownership across nodes

### DIFF
--- a/src/mem3_util.erl
+++ b/src/mem3_util.erl
@@ -182,10 +182,8 @@ ensure_exists(DbName) ->
 
 owner(DbName, DocId) ->
     Shards = mem3:shards(DbName, DocId),
-    Nodes = [node()|nodes()],
-    LiveShards = [S || #shard{node=Node} = S <- Shards, lists:member(Node, Nodes)],
-    [#shard{node=Node}] = lists:usort(fun(#shard{name=A}, #shard{name=B}) ->
-                                              A =< B  end, LiveShards),
+    Ushards = mem3:ushards(DbName),
+    [Node] = [N || #shard{node=N} = S <- Shards, lists:member(S, Ushards)],
     node() =:= Node.
 
 is_deleted(Change) ->


### PR DESCRIPTION
The previous algorithm was biased towards low-numbered nodes, and in the case of a 3 node cluster would declare db1 to be the owner of all replications.  We can do better just by leveraging the existing ushards code.

There's a possibility to refactor this as a new ushards/2 function if that's perceived as useful.

BugzID: 19870
