### PR TITLE
Zero out shard caches on upgrade

### DIFF
--- a/src/mem3_shards.erl
+++ b/src/mem3_shards.erl
@@ -198,7 +198,7 @@ terminate(_Reason, #st{changes_pid=Pid}) ->
     ok.
 
 code_change(_OldVsn, St, _Extra) ->
-    {ok, St}.
+    {ok, cache_clear(St)}.
 
 %% internal functions
 


### PR DESCRIPTION
The mix of #shard and #ordered_shard records breaks ushards.  Different nodes can start returning different results.  Particularly problematic for dbcopy, as it's possible to end up in a situation where none of the nodes considers itself responsible for propagation of results.
