### PR TITLE
Fix load_shards_from_disk/2

### DIFF
--- a/src/mem3_shards.erl
+++ b/src/mem3_shards.erl
@@ -283,7 +283,11 @@ load_shards_from_db(#db{} = ShardDb, DbName) ->
 load_shards_from_disk(DbName, DocId)->
     Shards = load_shards_from_disk(DbName),
     HashKey = mem3_util:hash(DocId),
-    [S || #shard{range = [B,E]} = S <- Shards, B =< HashKey, HashKey =< E].
+    [S || S <- Shards, in_range(S, HashKey)].
+
+in_range(Shard, HashKey) ->
+    [B, E] = mem3:range(Shard),
+    B =< HashKey andalso HashKey =< E.
 
 create_if_missing(Name) ->
     DbDir = config:get("couchdb", "database_dir"),


### PR DESCRIPTION
load_shards_from_disk/2 did not expect #ordered_shards to be returned
from load_shards_from_disk/1. Since it uses a list comprehension the
mistake is silently squashed, resulting in an empty list.

In production this manifests are the occasional failure, where 'n' is
calculated as 0, causing quorum reads to fail. The very next call
succeeds as it reads the cached versions and correctly downcasts.

BugzID: 20629
