### PR TITLE
Fix latent single-shard range hack

### DIFF
--- a/src/mem3.erl
+++ b/src/mem3.erl
@@ -95,7 +95,7 @@ shards_int(DbName, Options) ->
             node = node(),
             name = ShardDbName,
             dbname = ShardDbName,
-            range = [0, 2 bsl 31],
+            range = [0, (2 bsl 31)-1],
             order = undefined}];
     ShardDbName ->
         %% shard_db is treated as a single sharded db to support calls to db_info
@@ -104,7 +104,7 @@ shards_int(DbName, Options) ->
             node = node(),
             name = ShardDbName,
             dbname = ShardDbName,
-            range = [0, 2 bsl 31]}];
+            range = [0, (2 bsl 31)-1]}];
     _ ->
         mem3_shards:for_db(DbName, Options)
     end.


### PR DESCRIPTION
We had an off-by-one error when we fake #shard{} records for node local
databases. This fixes the issue. The bug was noticeable when attempting
to pass these shards to `fabric_view:is_progress_possible/1`.

BugzId: 22809
