### PR TITLE
Avoid decom:true nodes when fixing zoning

### DIFF
--- a/src/mem3_rebalance.erl
+++ b/src/mem3_rebalance.erl
@@ -400,7 +400,7 @@ apply_shard_moves(Shards, [{copy, Shard, Node}| Rest]) ->
 allowed_nodes(Fun) ->
     lists:filter(fun(Node) ->
         Fun(mem3:node_info(Node, <<"zone">>))
-    end, mem3:nodes()).
+    end, surviving_nodes()).
 
 surviving_nodes() ->
     lists:filter(fun(Node) ->


### PR DESCRIPTION
This patch prevents mem3_rebalance:fix_zoning from suggesting moves
onto nodes that are flagged with "decom":true.

BugzID: 26362
