### PR TITLE
Fast forward internal repl. between file copies

### DIFF
--- a/src/mem3_rep.erl
+++ b/src/mem3_rep.erl
@@ -202,9 +202,18 @@ calculate_start_seq(Acc) ->
             end,
             Acc1#acc{seq = Seq, history = History};
         {not_found, _} ->
-            Acc1
+            compare_epochs(Acc1)
     end.
 
+compare_epochs(Acc) ->
+    #acc{
+        source = Db,
+        target = #shard{node=Node, name=Name}
+    } = Acc,
+    UUID = couch_db:get_uuid(Db),
+    Epochs = couch_db:get_epochs(Db),
+    Seq = mem3_rpc:find_common_seq(Node, Name, UUID, Epochs),
+    Acc#acc{seq = Seq, history = {[]}}.
 
 changes_enumerator(FDI, _, #acc{revcount=C, infos=Infos}=Acc0) ->
     #doc_info{


### PR DESCRIPTION
In the case where two files have the same UUID we can analyze epoch information to determine the safe start sequence.

BugzID: 27753
