### PR TITLE
Fix race when the database did not exist before starting.

### DIFF
--- a/src/mem3_util.erl
+++ b/src/mem3_util.erl
@@ -221,9 +221,13 @@ ensure_exists(DbName) ->
     {ok, Db} ->
         {ok, Db};
     _ ->
-        couch_server:create(DbName, Options)
+        case couch_server:create(DbName, Options) of
+        {ok, Db} ->
+            {ok, Db};
+        file_exists -> % harmless race
+            {ok, Db} = couch_db:open(DbName, Options)
+        end
     end.
-
 
 is_deleted(Change) ->
     case couch_util:get_value(<<"deleted">>, Change) of


### PR DESCRIPTION
Fix race when the database did not exist before starting.

Parallel calls to `mem3_util:ensure_exists/1` can both find that the database does not exist and when trying to create it, one will loose out and receive `file_exists` back from `couch_server:create/1` via `mem3_util:ensure_exists`, instead of expected `{ok, Db}`.

Fixed by re-attempting `couch_db:open/1` after finding that the file could not be created.

A test for one specific occurrence is in dbcore/37960-db-creation-race, see git log there, `make check`.

BugzID: 37960
