### PR TITLE
Fix mem3_rebalance for single-letter DBs.

### DIFF
--- a/src/mem3_rebalance.erl
+++ b/src/mem3_rebalance.erl
@@ -489,7 +489,7 @@ print({Op, Shard, TargetNode} = Operation) ->
     ),
     {match, [Range, Account, DbName]} = re:run(
         Shard#shard.name,
-        "shards/(?<range>[0-9a-f\-]+)/(?<account>.+)/(?<dbname>[a-z\\_][a-z0-9\\_\\$()\\+\\-\\/]+)\.[0-9]{8}",
+        "shards/(?<range>[0-9a-f\-]+)/(?<account>.+)/(?<dbname>[a-z\\_][a-z0-9\\_\\$()\\+\\-\\/]*)\.[0-9]{8}",
         [{capture, all_but_first, binary}]
     ),
     OpName = case Op of move -> move2; _ -> Op end,


### PR DESCRIPTION
This corrects a fault where plan generation would succeed but printing
the plan would fail.

See chttp_db for the allowed DB name format.

BugzId: 49932