### PR TITLE
Remove cached shards for non-existent dbs

### DIFF
--- a/src/mem3_shards.erl
+++ b/src/mem3_shards.erl
@@ -280,8 +280,14 @@ load_shards_from_db(#db{} = ShardDb, DbName) ->
         gen_server:cast(?MODULE, {cache_insert, DbName, Shards}),
         Shards;
     {not_found, _} ->
+        cluster_cache_remove(DbName),
         erlang:error(database_does_not_exist, ?b2l(DbName))
     end.
+
+cluster_cache_remove(DbName) ->
+    lists:foreach(fun(Node) ->
+        gen_server:cast({mem3_shards, Node}, {cache_remove, DbName})
+    end, mem3:nodes()).
 
 load_shards_from_disk(DbName, DocId)->
     Shards = load_shards_from_disk(DbName),


### PR DESCRIPTION
When a database is deleted, a race can occur that will sometimes leave
its shard map present on one or more nodes in the cluster, which
generates a huge amount of logging.

When a request to mem3_shards:load_shards_from_db/2 results in
not_found, this sends a cast to mem3_shards on each node to remove the
shards for the specified DbName.

BugsID: 77475