### PR TITLE
Support mem3_shards hot upgrade

### DIFF
--- a/src/mem3_shards.erl
+++ b/src/mem3_shards.erl
@@ -249,7 +249,10 @@ code_change(1 = OldVsn, {st, MaxSize, CurSize, ChangesPid} = St, _Extra) ->
 code_change({down, 2} = OldVsn, St, _Extra) ->
     {st, MaxSize, CurSize, ChangesPid, _, _} = St,
     twig:log(notice, "~p code_change ~p ~p", [?MODULE, OldVsn, St]),
-    downgrade(MaxSize, CurSize, ChangesPid).
+    downgrade(MaxSize, CurSize, ChangesPid);
+
+code_change(_OldVsn, #st{} = St, _Extra) ->
+    {ok, St}.
 
 
 upgrade(MaxSize, CurSize, ChangesPid) ->

--- a/src/mem3_shards.erl
+++ b/src/mem3_shards.erl
@@ -14,7 +14,7 @@
 
 -module(mem3_shards).
 -behaviour(gen_server).
--vsn(1).
+-vsn(2).
 -behaviour(config_listener).
 
 -export([init/1, terminate/2, code_change/3]).
@@ -242,7 +242,49 @@ terminate(_Reason, #st{changes_pid=Pid}) ->
     exit(Pid, kill),
     ok.
 
-code_change(_OldVsn, #st{}=St, _Extra) ->
+code_change(1 = OldVsn, {st, MaxSize, CurSize, ChangesPid} = St, _Extra) ->
+    twig:log(notice, "~p code_change ~p ~p", [?MODULE, OldVsn, St]),
+    upgrade(MaxSize, CurSize, ChangesPid);
+
+code_change({down, 2} = OldVsn, St, _Extra) ->
+    {st, MaxSize, CurSize, ChangesPid, _, _} = St,
+    twig:log(notice, "~p code_change ~p ~p", [?MODULE, OldVsn, St]),
+    downgrade(MaxSize, CurSize, ChangesPid).
+
+
+upgrade(MaxSize, CurSize, ChangesPid) ->
+    %% recreate shards table
+    ShardsStash = ets:tab2list(?SHARDS),
+    ets:delete(?SHARDS),
+    ets:new(?SHARDS, [
+        bag,
+        public,
+        named_table,
+        {keypos,#shard.dbname},
+        {read_concurrency, true}
+    ]),
+    ets:insert(?SHARDS, ShardsStash),
+
+    %% create new table
+    ets:new(?OPENERS, [bag, public, named_table]),
+
+    %% add new record entries
+    St = #st{
+        max_size = MaxSize,
+        cur_size = CurSize,
+        changes_pid = ChangesPid,
+        update_seq = get_update_seq(),
+        write_timeout = config:get_integer("mem3", "shard_write_timeout", 1000)
+    },
+    {ok, St}.
+
+downgrade(MaxSize, CurSize, ChangesPid) ->
+    %% explicitly leave shards table public, and read_concurrent (unchanged)
+
+    %% delete new table
+    ets:delete(?OPENERS),
+
+    St = {st, MaxSize, CurSize, ChangesPid},
     {ok, St}.
 
 %% internal functions

--- a/src/mem3_shards.erl
+++ b/src/mem3_shards.erl
@@ -328,7 +328,7 @@ changes_callback(timeout, _) ->
     ok.
 
 load_shards_from_disk(DbName) when is_binary(DbName) ->
-    couch_stats:increment_counter([mem3, shard_cache, miss]),
+    couch_stats:increment_counter([dbcore, mem3, shard_cache, miss]),
     X = ?l2b(config:get("mem3", "shard_db", "dbs")),
     {ok, Db} = mem3_util:ensure_exists(X),
     try


### PR DESCRIPTION
I tested the upgrade and downgrade paths by first making sure mem3_shards was compiled from tag 3.9.2, then updating the source with this patch, recompiling, then in a remsh
```erlang
f(_change_code), _change_code = fun(Module, OldVsn) ->
    ok = sys:suspend(Module),
    {module, Module} = l(Module),
    ok = sys:change_code(Module, Module, OldVsn, []),
    ok = sys:resume(Module)
end.

f(_table_exists), _table_exists = fun(Tab) ->
    try ets:tab2list(Tab) of
        Val ->
            true
    catch
        error:badarg ->
            false
    end
end.

f(_state_size), _state_size = fun(Name) ->
    size(sys:get_state(Name)) - 1 % exclude tag
end.

f(_validate), _validate = fun
    (pre) ->
        false = _table_exists(mem3_openers),
        3 == _state_size(mem3_shards),
        ok;
    (post)->
        true = _table_exists(mem3_openers),
        5 == _state_size(mem3_shards),
        ok
end.

ok = _validate(pre).
ok = _change_code(mem3_shards, 1).
ok = _validate(post).
ok = _change_code(mem3_shards, {down, 2}).
ok = _validate(pre).
```
